### PR TITLE
Update to the cfg

### DIFF
--- a/fitConfig/fitMuon.py
+++ b/fitConfig/fitMuon.py
@@ -553,7 +553,7 @@ if _id == "highpt" :
     )
     PT_ALLETA_BINS = cms.PSet(
         #Main
-        pair_newTuneP_probe_pt     = cms.vdouble(20, 25, 30, 40, 50, 55, 60, 80, 120, 250, 500),
+        pair_newTuneP_probe_pt     = cms.vdouble(20, 25, 30, 40, 50, 55, 60, 80, 120, 200, 500),
         abseta = cms.vdouble(  0.0, 2.4),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
@@ -564,7 +564,7 @@ if _id == "highpt" :
     PT_ETA_BINS = cms.PSet(
         #Main
         #pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
-        pair_newTuneP_probe_pt     = cms.vdouble(20, 25, 30, 40, 50, 55, 60, 120, 250, 500),
+        pair_newTuneP_probe_pt     = cms.vdouble(20, 25, 30, 40, 50, 55, 60, 120, 200, 500),
         #For testing bkg function
         #pt     = cms.vdouble(60, 80, 120, 200),
         abseta = cms.vdouble( 0., 0.9, 1.2, 2.1, 2.4),
@@ -576,7 +576,7 @@ if _id == "highpt" :
         
     )
     PT_HIGHABSETA = cms.PSet(
-        pair_newTuneP_probe_pt     = cms.vdouble(20, 30, 40, 50, 55, 60, 80, 120,  250, 500),
+        pair_newTuneP_probe_pt     = cms.vdouble(20, 30, 40, 50, 55, 60, 80, 120,  200, 500),
         abseta = cms.vdouble(2.1, 2.4),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
@@ -635,7 +635,7 @@ else:
     )
     PT_ALLETA_BINS = cms.PSet(
         #Main
-        pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 250, 500),
+        pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200, 500),
         abseta = cms.vdouble(  0.0, 2.4),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
@@ -646,7 +646,7 @@ else:
     PT_ETA_BINS = cms.PSet(
         #Main
         #pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
-        pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120, 250, 500),
+        pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120, 200, 500),
         #For testing bkg function
         #pt     = cms.vdouble(60, 80, 120, 200),
         abseta = cms.vdouble( 0., 0.9, 1.2, 2.1, 2.4),
@@ -658,7 +658,7 @@ else:
         
     )
     PT_HIGHABSETA = cms.PSet(
-        pt     = cms.vdouble(20, 30, 40, 50, 60, 80, 120, 250, 500),
+        pt     = cms.vdouble(20, 30, 40, 50, 60, 80, 120, 200, 500),
         abseta = cms.vdouble(2.1, 2.4),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
@@ -710,7 +710,7 @@ LOOSE_COARSE_ETA_BINS = cms.PSet(
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 LOOSE_PT_ALLETA_BINS = cms.PSet(
-    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 250, 500),
+    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200, 500),
     abseta = cms.vdouble(  0.0, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     PF = cms.vstring("pass"), 
@@ -721,7 +721,7 @@ LOOSE_PT_ALLETA_BINS = cms.PSet(
 )
 LOOSE_PT_ETA_BINS = cms.PSet(
     #pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
-    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120,  250, 500),
+    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120,  200, 500),
     abseta = cms.vdouble( 0., 0.9, 1.2, 2.1, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     PF = cms.vstring("pass"), 
@@ -775,7 +775,7 @@ MEDIUM_COARSE_ETA_BINS = cms.PSet(
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 MEDIUM_PT_ALLETA_BINS = cms.PSet(
-    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 250, 500),
+    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200, 500),
     abseta = cms.vdouble(  0.0, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     Medium = cms.vstring("pass"), 
@@ -786,7 +786,7 @@ MEDIUM_PT_ALLETA_BINS = cms.PSet(
 )
 MEDIUM_PT_ETA_BINS = cms.PSet(
     #pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
-    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120, 250, 500),
+    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120, 200, 500),
     abseta = cms.vdouble( 0., 0.9, 1.2, 2.1, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     Medium = cms.vstring("pass"), 
@@ -843,7 +843,7 @@ TIGHT_COARSE_ETA_BINS = cms.PSet(
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 TIGHT_PT_ALLETA_BINS = cms.PSet(
-    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120,  250, 500),
+    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120,  200, 500),
     abseta = cms.vdouble(  0.0, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     Tight2012 = cms.vstring("pass"), 
@@ -855,7 +855,7 @@ TIGHT_PT_ALLETA_BINS = cms.PSet(
 )
 TIGHT_PT_ETA_BINS = cms.PSet(
     #pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
-    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120, 250, 500),
+    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120, 200, 500),
     abseta = cms.vdouble( 0., 0.9, 1.2, 2.1, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     Tight2012 = cms.vstring("pass"), 
@@ -926,7 +926,7 @@ HIGHPT_COARSE_ETA_BINS = cms.PSet(
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 HIGHPT_PT_ALLETA_BINS = cms.PSet(
-    pair_newTuneP_probe_pt     = cms.vdouble(20, 25, 30, 40, 50, 55, 60, 80, 120,  250, 500),
+    pair_newTuneP_probe_pt     = cms.vdouble(20, 25, 30, 40, 50, 55, 60, 80, 120,  200, 500),
     abseta = cms.vdouble(  0.0, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     HighPt = cms.vstring("pass"), 
@@ -938,7 +938,7 @@ HIGHPT_PT_ALLETA_BINS = cms.PSet(
 )
 HIGHPT_PT_ETA_BINS = cms.PSet(
     #pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
-    pair_newTuneP_probe_pt     = cms.vdouble(20, 25, 30, 40, 50, 55, 60, 120,  250, 500),
+    pair_newTuneP_probe_pt     = cms.vdouble(20, 25, 30, 40, 50, 55, 60, 120,  200, 500),
     abseta = cms.vdouble( 0., 0.9, 1.2, 2.1, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     HighPt = cms.vstring("pass"), 

--- a/fitConfig/fitMuon.py
+++ b/fitConfig/fitMuon.py
@@ -181,19 +181,19 @@ elif _id == "medium":
             ),
     
         Categories = cms.PSet(
-            Medium   = cms.vstring("Medium Id. Muon", "dummy[pass=1,fail=0]"),
+            Medium2016  = cms.vstring("Medium Id. Muon (ICHEP version)", "dummy[pass=1,fail=0]"),
             #tag selection
             tag_IsoMu22 = cms.vstring("PF Muon", "dummy[pass=1,fail=0]"),
         ),
     
         Expressions = cms.PSet(
             #ID 
-            Medium_noIPVar= cms.vstring("Medium_noIPVar", "Medium==1", "Medium"),
+            Medium2016_noIPVar= cms.vstring("Medium2016_noIPVar", "Medium2016==1", "Medium2016"),
         ),
     
         Cuts = cms.PSet(
             #ID
-            Medium_noIP= cms.vstring("Medium_noIP", "Medium_noIPVar", "0.5"),
+            Medium2016_noIP= cms.vstring("Medium2016_noIP", "Medium2016_noIPVar", "0.5"),
             #Isolations
             LooseIso4 = cms.vstring("LooseIso4" ,"combRelIsoPF04dBeta", "0.25"),
             TightIso4 = cms.vstring("TightIso4" ,"combRelIsoPF04dBeta", "0.15"),
@@ -757,7 +757,7 @@ MEDIUM_ETA_BINS = cms.PSet(
     pt  = cms.vdouble(20, 500),
     eta = cms.vdouble(-2.4, -2.1, -1.6, -1.2, -0.9, -0.3, -0.2, 0.2, 0.3, 0.9, 1.2, 1.6, 2.1, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
-    Medium = cms.vstring("pass"), 
+    Medium2016 = cms.vstring("pass"), 
     #tag selections
     tag_pt = cms.vdouble(23, 500),
     tag_IsoMu22 = cms.vstring("pass"), 
@@ -768,7 +768,7 @@ MEDIUM_COARSE_ETA_BINS = cms.PSet(
     pt     = cms.vdouble(20, 500),
     abseta = cms.vdouble(0.0, 0.9, 1.2, 2.1, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
-    Medium = cms.vstring("pass"), 
+    Medium2016 = cms.vstring("pass"), 
     #tag selections
     tag_pt = cms.vdouble(23, 500),
     tag_IsoMu22 = cms.vstring("pass"), 
@@ -778,7 +778,7 @@ MEDIUM_PT_ALLETA_BINS = cms.PSet(
     pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200, 500),
     abseta = cms.vdouble(  0.0, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
-    Medium = cms.vstring("pass"), 
+    Medium2016 = cms.vstring("pass"), 
     #tag selections
     tag_pt = cms.vdouble(23, 500),
     tag_IsoMu22 = cms.vstring("pass"), 
@@ -789,7 +789,7 @@ MEDIUM_PT_ETA_BINS = cms.PSet(
     pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120, 200, 500),
     abseta = cms.vdouble( 0., 0.9, 1.2, 2.1, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
-    Medium = cms.vstring("pass"), 
+    Medium2016 = cms.vstring("pass"), 
     #tag selections
     tag_pt = cms.vdouble(23, 500),
     tag_IsoMu22 = cms.vstring("pass"), 
@@ -801,7 +801,7 @@ MEDIUM_VTX_BINS_ETA24  = cms.PSet(
     abseta = cms.vdouble(  0.0, 2.4),
     tag_nVertices = cms.vdouble(0.5,2.5,4.5,6.5,8.5,10.5,12.5,14.5,16.5,18.5,20.5,22.5,24.5,26.5,28.5,30.5),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
-    Medium = cms.vstring("pass"), 
+    Medium2016 = cms.vstring("pass"), 
     #tag selections
     tag_pt = cms.vdouble(23, 500),
     tag_IsoMu22 = cms.vstring("pass"),
@@ -812,7 +812,7 @@ MEDIUM_PHI_BINS = cms.PSet(
     abseta = cms.vdouble(  0.0, 2.4),
     phi =  cms.vdouble(-3.1416, -2.618, -2.0944, -1.5708, -1.0472, -0.5236, 0, 0.5236, 1.0472, 1.5708, 2.0944, 2.618, 3.1416),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
-    Medium = cms.vstring("pass"), 
+    Medium2016 = cms.vstring("pass"), 
     #tag selections
     tag_pt = cms.vdouble(23, 500),
     tag_IsoMu22 = cms.vstring("pass"),
@@ -1079,23 +1079,23 @@ if _id == 'loose' and _iso == 'noiso':
 elif _id == 'medium' and _iso == 'noiso':
     if binning == 'eta':
         ID_BINS = [
-        (("Medium_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_eta", ETA_BINS)),
+        (("Medium2016_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_eta", ETA_BINS)),
         ]
     elif binning == 'pt_alleta':
         ID_BINS = [
-        (("Medium_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_pt_alleta_bin1", PT_ALLETA_BINS)),
+        (("Medium2016_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_pt_alleta_bin1", PT_ALLETA_BINS)),
         ]
     elif binning == 'pt_spliteta':
         ID_BINS = [
-        (("Medium_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_pt_spliteta_bin1", PT_ETA_BINS)),
+        (("Medium2016_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_pt_spliteta_bin1", PT_ETA_BINS)),
         ]
     elif binning == 'all':
         ID_BINS = [
-        #(("Medium_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_eta", ETA_BINS)),
-        #(("Medium_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_pt_alleta_bin1", PT_ALLETA_BINS)),
-        #(("Medium_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_pt_spliteta_bin1", PT_ETA_BINS)),
-        (("Medium_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_pt_vtx", VTX_BINS_ETA24)),
-        (("Medium_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_pt_phi", PHI_BINS)),
+        #(("Medium2016_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_eta", ETA_BINS)),
+        #(("Medium2016_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_pt_alleta_bin1", PT_ALLETA_BINS)),
+        #(("Medium2016_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_pt_spliteta_bin1", PT_ETA_BINS)),
+        (("Medium2016_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_pt_vtx", VTX_BINS_ETA24)),
+        (("Medium2016_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_pt_phi", PHI_BINS)),
         ]
         
 #Tight ID

--- a/fitConfig/fitMuon.py
+++ b/fitConfig/fitMuon.py
@@ -564,7 +564,7 @@ if _id == "highpt" :
     PT_ETA_BINS = cms.PSet(
         #Main
         #pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
-        pair_newTuneP_probe_pt     = cms.vdouble(20, 25, 30, 40, 50, 55, 60, 120, 200, 500),
+        pair_newTuneP_probe_pt     = cms.vdouble(20, 25, 30, 40, 50, 55, 60, 80, 120, 200, 500),
         #For testing bkg function
         #pt     = cms.vdouble(60, 80, 120, 200),
         abseta = cms.vdouble( 0., 0.9, 1.2, 2.1, 2.4),
@@ -576,7 +576,7 @@ if _id == "highpt" :
         
     )
     PT_HIGHABSETA = cms.PSet(
-        pair_newTuneP_probe_pt     = cms.vdouble(20, 30, 40, 50, 55, 60, 80, 120,  200, 500),
+        pair_newTuneP_probe_pt     = cms.vdouble(20, 30, 40, 50, 55, 60, 80, 120, 200, 500),
         abseta = cms.vdouble(2.1, 2.4),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
@@ -646,7 +646,7 @@ else:
     PT_ETA_BINS = cms.PSet(
         #Main
         #pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
-        pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120, 200, 500),
+        pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200, 500),
         #For testing bkg function
         #pt     = cms.vdouble(60, 80, 120, 200),
         abseta = cms.vdouble( 0., 0.9, 1.2, 2.1, 2.4),
@@ -721,7 +721,7 @@ LOOSE_PT_ALLETA_BINS = cms.PSet(
 )
 LOOSE_PT_ETA_BINS = cms.PSet(
     #pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
-    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120,  200, 500),
+    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120,  200, 500),
     abseta = cms.vdouble( 0., 0.9, 1.2, 2.1, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     PF = cms.vstring("pass"), 
@@ -786,7 +786,7 @@ MEDIUM_PT_ALLETA_BINS = cms.PSet(
 )
 MEDIUM_PT_ETA_BINS = cms.PSet(
     #pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
-    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120, 200, 500),
+    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200, 500),
     abseta = cms.vdouble( 0., 0.9, 1.2, 2.1, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     Medium2016 = cms.vstring("pass"), 
@@ -855,7 +855,7 @@ TIGHT_PT_ALLETA_BINS = cms.PSet(
 )
 TIGHT_PT_ETA_BINS = cms.PSet(
     #pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
-    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120, 200, 500),
+    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200, 500),
     abseta = cms.vdouble( 0., 0.9, 1.2, 2.1, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     Tight2012 = cms.vstring("pass"), 
@@ -938,7 +938,7 @@ HIGHPT_PT_ALLETA_BINS = cms.PSet(
 )
 HIGHPT_PT_ETA_BINS = cms.PSet(
     #pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
-    pair_newTuneP_probe_pt     = cms.vdouble(20, 25, 30, 40, 50, 55, 60, 120,  200, 500),
+    pair_newTuneP_probe_pt     = cms.vdouble(20, 25, 30, 40, 50, 55, 60, 80, 120, 200, 500),
     abseta = cms.vdouble( 0., 0.9, 1.2, 2.1, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     HighPt = cms.vstring("pass"), 
@@ -1416,12 +1416,13 @@ for ID, ALLBINS in ID_BINS:
     shape = cms.vstring("vpvPlusExpo")
     #shape = "vpvPlusCheb"
     if not "Iso" in ID:  #customize only for ID
-        if (len(B.pt)==7): #customize only when the pT have the high pt bins
-            shape = cms.vstring("vpvPlusExpo","*pt_bin4*","vpvPlusCheb","*pt_bin5*","vpvPlusCheb")
-        elif (len(B.pt)==9): 
-            shape = cms.vstring("vpvPlusExpo","*pt_bin5*","vpvPlusCheb","*pt_bin6*","vpvPlusCheb","*pt_bin7*","vpvPlusCheb")
-    DEN = B.clone(); num = ID;
-    
+        if _id == "highpt" :
+            elif (len(B.pair_newTuneP_probe_pt)==11): 
+                shape = cms.vstring("vpvPlusExpo","*pt_bin6*","vpvPlusCheb","*pt_bin7*","vpvPlusCheb","*pt_bin8*","vpvPlusCheb","*pt_bin9*","vpvPlusCheb")
+        else:
+            elif (len(B.pt)==10): 
+                shape = cms.vstring("vpvPlusExpo","*pt_bin5*","vpvPlusCheb","*pt_bin6*","vpvPlusCheb","*pt_bin7*","vpvPlusCheb","*pt_bin8*","vpvPlusCheb")
+    DEN = B.clone(); num = ID;    
 
     #compute isolation efficiency 
     if scenario == 'data_all':

--- a/fitConfig/fitMuon.py
+++ b/fitConfig/fitMuon.py
@@ -464,11 +464,13 @@ elif _id == 'soft':
         Expressions = cms.PSet(
             #ID 
             SoftVar = cms.vstring("SoftVar", "TMOST == 1 && tkTrackerLay > 5 && tkPixelLay > 0 && abs(dzPV) < 20 && abs(dB) < 0.3 && Track_HP == 1", "TMOST","tkTrackerLay", "tkPixelLay", "dzPV", "dB", "Track_HP"),
+            SoftVar2016 = cms.vstring("SoftVar", "TMOST == 1 && tkTrackerLay > 5 && tkPixelLay > 0 && abs(dzPV) < 20 && abs(dB) < 0.3", "TMOST","tkTrackerLay", "tkPixelLay", "dzPV", "dB"),
         ),
     
         Cuts = cms.PSet(
             #ID
             SoftID = cms.vstring("Soft", "SoftVar", "0.5"),
+            SoftID2016 = cms.vstring("Soft2016", "SoftVar2016", "0.5"),
         ),
     
                               
@@ -605,7 +607,7 @@ if _id == "highpt" :
         tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
     )
 else:
-        ETA_BINS = cms.PSet(
+    ETA_BINS = cms.PSet(
         pt  = cms.vdouble(20, 500),
         eta = cms.vdouble(-2.4, -2.1, -1.6, -1.2, -0.9, -0.3, -0.2, 0.2, 0.3, 0.9, 1.2, 1.6, 2.1, 2.4),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
@@ -1022,7 +1024,8 @@ if sample == "data":
     process.TnP_MuonID = Template.clone(
         InputFileNames = cms.vstring(
             #'root://eoscms//eos/cms//store/group/phys_muon/TagAndProbe/Run2016/80X_v1/data/TnPTree_80X_Run2016B_v2_DCSOnly_RunList.root'
-            '../Production/TnPTree_80X_Run2016B_v2_DCSOnly_RunList.root'
+            #'../Production/TnPTree_80X_Run2016B_v2_DCSOnly_RunList.root'
+            '/data/battilan/Commissioning2016/TnP/TnPTree_80X_Run2016C_v2_GoldenJSON_Run275126to275783.root'            
             ),
         InputTreeName = cms.string("fitter_tree"),
         InputDirectoryName = cms.string("tpTree"),
@@ -1071,7 +1074,7 @@ if _id == 'loose' and _iso == 'noiso':
         (("Loose_noIP"), ("NUM_LooseID_DEN_genTracks_PAR_eta", ETA_BINS)),
         (("Loose_noIP"), ("NUM_LooseID_DEN_genTracks_PAR_pt_alleta_bin1", PT_ALLETA_BINS)),
         (("Loose_noIP"), ("NUM_LooseID_DEN_genTracks_PAR_pt_spliteta_bin1", PT_ETA_BINS)),
-        #(("Loose_noIP"), ("NUM_LooseID_DEN_genTracks_PAR_pt_vtx", VTX_BINS_ETA26)),
+        (("Loose_noIP"), ("NUM_LooseID_DEN_genTracks_PAR_pt_vtx", VTX_BINS_ETA24)),
         #(("Loose_noIP"), ("NUM_LooseID_DEN_genTracks_PAR_phi", PHI_BINS)),
         ]
 
@@ -1091,11 +1094,11 @@ elif _id == 'medium' and _iso == 'noiso':
         ]
     elif binning == 'all':
         ID_BINS = [
-        #(("Medium2016_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_eta", ETA_BINS)),
-        #(("Medium2016_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_pt_alleta_bin1", PT_ALLETA_BINS)),
-        #(("Medium2016_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_pt_spliteta_bin1", PT_ETA_BINS)),
+        (("Medium2016_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_eta", ETA_BINS)),
+        (("Medium2016_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_pt_alleta_bin1", PT_ALLETA_BINS)),
+        (("Medium2016_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_pt_spliteta_bin1", PT_ETA_BINS)),
         (("Medium2016_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_pt_vtx", VTX_BINS_ETA24)),
-        (("Medium2016_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_pt_phi", PHI_BINS)),
+        #(("Medium2016_noIP"), ("NUM_MediumID_DEN_genTracks_PAR_pt_phi", PHI_BINS)),
         ]
         
 #Tight ID
@@ -1117,7 +1120,7 @@ elif _id == 'tight' and _iso == 'noiso':
         (("Tight2012_zIPCut"), ("NUM_TightIDandIPCut_DEN_genTracks_PAR_eta", ETA_BINS)),
         (("Tight2012_zIPCut"), ("NUM_TightIDandIPCut_DEN_genTracks_PAR_pt_alleta_bin1", PT_ALLETA_BINS)),
         (("Tight2012_zIPCut"), ("NUM_TightIDandIPCut_DEN_genTracks_PAR_pt_spliteta_bin1", PT_ETA_BINS)),
-        #(("Tight2012_zIPCut"), ("NUM_TightIDandIPCut_DEN_genTracks_PAR_vtx", VTX_BINS_ETA24)),
+        (("Tight2012_zIPCut"), ("NUM_TightIDandIPCut_DEN_genTracks_PAR_vtx", VTX_BINS_ETA24)),
         #(("Tight2012_zIPCut"), ("NUM_TightIDandIPCut_DEN_genTracks_PAR_phi", PHI_BINS)),
         ]
 
@@ -1142,7 +1145,7 @@ elif _id == 'highpt' and _iso == 'noiso':
         (("HighPt_zIPCut"), ("NUM_HighPtIDandIPCut_DEN_genTracks_PAR_eta", ETA_BINS_HPT)),
         (("HighPt_zIPCut"), ("NUM_HighPtIDandIPCut_DEN_genTracks_PAR_pt_alleta_bin1", PT_ALLETA_BINS)),
         (("HighPt_zIPCut"), ("NUM_HighPtIDandIPCut_DEN_genTracks_PAR_pt_spliteta_bin1", PT_ETA_BINS)),
-        #(("HighPt_zIPCut"), ("NUM_HighPtIDandIPCut_DEN_genTracks_PAR_vtx", VTX_BINS_ETA24)),
+        (("HighPt_zIPCut"), ("NUM_HighPtIDandIPCut_DEN_genTracks_PAR_vtx", VTX_BINS_ETA24)),
         #(("HighPt_zIPCut"), ("NUM_HighPtIDandIPCut_DEN_genTracks_PAR_phi", PHI_BINS)),
         ]
 
@@ -1150,21 +1153,22 @@ elif _id == 'highpt' and _iso == 'noiso':
 elif _id == 'soft' and _iso == 'noiso':
     if binning == 'eta':
         ID_BINS = [
-        (("SoftID"), ("NUM_SoftID_DEN_genTracks_PAR_eta", ETA_BINS)),
+        (("SoftID2016"), ("NUM_SoftID_DEN_genTracks_PAR_eta", ETA_BINS)),
         ]
     elif binning == 'pt_alleta':
         ID_BINS = [
-        (("SoftID"), ("NUM_SoftID_DEN_genTracks_PAR_pt_alleta_bin1", PT_ALLETA_BINS)),
+        (("SoftID2016"), ("NUM_SoftID_DEN_genTracks_PAR_pt_alleta_bin1", PT_ALLETA_BINS)),
         ]
     elif binning == 'pt_spliteta':
         ID_BINS = [
-        (("SoftID"), ("NUM_SoftID_DEN_genTracks_PAR_pt_spliteta_bin1", PT_ETA_BINS)),
+        (("SoftID2016"), ("NUM_SoftID_DEN_genTracks_PAR_pt_spliteta_bin1", PT_ETA_BINS)),
         ]
     elif binning == 'all':
         ID_BINS = [
-        (("SoftID"), ("NUM_SoftID_DEN_genTracks_PAR_eta", ETA_BINS)),
-        (("SoftID"), ("NUM_SoftID_DEN_genTracks_PAR_pt_alleta_bin1", PT_ALLETA_BINS)),
-        (("SoftID"), ("NUM_SoftID_DEN_genTracks_PAR_pt_spliteta_bin1", PT_ETA_BINS)),
+        (("SoftID2016"), ("NUM_SoftID_DEN_genTracks_PAR_eta", ETA_BINS)),
+        (("SoftID2016"), ("NUM_SoftID_DEN_genTracks_PAR_pt_alleta_bin1", PT_ALLETA_BINS)),
+        (("SoftID2016"), ("NUM_SoftID_DEN_genTracks_PAR_pt_spliteta_bin1", PT_ETA_BINS)),
+        (("SoftID2016"), ("NUM_SoftID_DEN_genTracks_PAR_vtx", VTX_BINS_ETA24)),
         ]
 
         
@@ -1187,11 +1191,11 @@ elif _id == 'loose' and _iso == 'loose':
         ]
     elif binning == 'all':
         ID_BINS = [
-        #(("LooseIso4"), ("NUM_LooseRelIso_DEN_LooseID_PAR_eta", LOOSE_ETA_BINS)),
-        #(("LooseIso4"), ("NUM_LooseRelIso_DEN_LooseID_PAR_pt_alleta_bin1", LOOSE_PT_ALLETA_BINS)),
-        #(("LooseIso4"), ("NUM_LooseRelIso_DEN_LooseID_PAR_pt_spliteta_bin1", LOOSE_PT_ETA_BINS)),
+        (("LooseIso4"), ("NUM_LooseRelIso_DEN_LooseID_PAR_eta", LOOSE_ETA_BINS)),
+        (("LooseIso4"), ("NUM_LooseRelIso_DEN_LooseID_PAR_pt_alleta_bin1", LOOSE_PT_ALLETA_BINS)),
+        (("LooseIso4"), ("NUM_LooseRelIso_DEN_LooseID_PAR_pt_spliteta_bin1", LOOSE_PT_ETA_BINS)),
         (("LooseIso4"), ("NUM_LooseRelIso_DEN_LooseID_PAR_vtx", LOOSE_VTX_BINS_ETA24)),
-        (("LooseIso4"), ("NUM_LooseRelIso_DEN_LooseID_PAR_phi", LOOSE_PHI_BINS)),
+        #(("LooseIso4"), ("NUM_LooseRelIso_DEN_LooseID_PAR_phi", LOOSE_PHI_BINS)),
         ]
 
 elif _id == 'medium' and _iso == 'loose':
@@ -1209,11 +1213,11 @@ elif _id == 'medium' and _iso == 'loose':
        ] 
     elif binning == 'all':
         ID_BINS = [
-        #(("LooseIso4"), ("NUM_LooseRelIso_DEN_MediumID_PAR_eta", MEDIUM_ETA_BINS)),
-        #(("LooseIso4"), ("NUM_LooseRelIso_DEN_MediumID_PAR_pt_alleta_bin1", MEDIUM_PT_ALLETA_BINS)),
-        #(("LooseIso4"), ("NUM_LooseRelIso_DEN_MediumID_PAR_pt_spliteta_bin1", MEDIUM_PT_ETA_BINS)),
+        (("LooseIso4"), ("NUM_LooseRelIso_DEN_MediumID_PAR_eta", MEDIUM_ETA_BINS)),
+        (("LooseIso4"), ("NUM_LooseRelIso_DEN_MediumID_PAR_pt_alleta_bin1", MEDIUM_PT_ALLETA_BINS)),
+        (("LooseIso4"), ("NUM_LooseRelIso_DEN_MediumID_PAR_pt_spliteta_bin1", MEDIUM_PT_ETA_BINS)),
         (("LooseIso4"), ("NUM_LooseRelIso_DEN_MediumID_PAR_vtx", MEDIUM_VTX_BINS_ETA24)),
-        (("LooseIso4"), ("NUM_LooseRelIso_DEN_MediumID_PAR_phi", MEDIUM_PHI_BINS)),
+        #(("LooseIso4"), ("NUM_LooseRelIso_DEN_MediumID_PAR_phi", MEDIUM_PHI_BINS)),
         ]
 
 elif _id == 'tight' and _iso == 'loose':
@@ -1231,11 +1235,11 @@ elif _id == 'tight' and _iso == 'loose':
         ]
     elif binning == 'all':
         ID_BINS = [
-        #(("LooseIso4"), ("NUM_LooseRelIso_DEN_TightID_PAR_eta", TIGHT_ETA_BINS)),
-        #(("LooseIso4"), ("NUM_LooseRelIso_DEN_TightID_PAR_pt_alleta_bin1", TIGHT_PT_ALLETA_BINS)),
-        #(("LooseIso4"), ("NUM_LooseRelIso_DEN_TightID_PAR_pt_spliteta_bin1", TIGHT_PT_ETA_BINS)),
+        (("LooseIso4"), ("NUM_LooseRelIso_DEN_TightID_PAR_eta", TIGHT_ETA_BINS)),
+        (("LooseIso4"), ("NUM_LooseRelIso_DEN_TightID_PAR_pt_alleta_bin1", TIGHT_PT_ALLETA_BINS)),
+        (("LooseIso4"), ("NUM_LooseRelIso_DEN_TightID_PAR_pt_spliteta_bin1", TIGHT_PT_ETA_BINS)),
         (("LooseIso4"), ("NUM_LooseRelIso_DEN_TightID_PAR_vtx", TIGHT_VTX_BINS_ETA24)),
-        (("LooseIso4"), ("NUM_LooseRelIso_DEN_TightID_PAR_phi", TIGHT_PHI_BINS)),
+        #(("LooseIso4"), ("NUM_LooseRelIso_DEN_TightID_PAR_phi", TIGHT_PHI_BINS)),
         ]
 
 #Tight Iso
@@ -1266,7 +1270,7 @@ elif _id == 'tight' and _iso == 'tight':
         (("TightIso4"), ("NUM_TightRelIso_DEN_TightID_PAR_pt_alleta_bin1", TIGHT_PT_ALLETA_BINS)),
         (("TightIso4"), ("NUM_TightRelIso_DEN_TightID_PAR_pt_spliteta_bin1", TIGHT_PT_ETA_BINS)),
         (("TightIso4"), ("NUM_TightRelIso_DEN_TightID_PAR_vtx", TIGHT_VTX_BINS_ETA24)),
-        (("TightIso4"), ("NUM_TightRelIso_DEN_TightID_PAR_phi", TIGHT_PHI_BINS)),
+        #(("TightIso4"), ("NUM_TightRelIso_DEN_TightID_PAR_phi", TIGHT_PHI_BINS)),
         ]
 
 elif _id == 'medium' and _iso == 'tight':
@@ -1287,7 +1291,7 @@ elif _id == 'medium' and _iso == 'tight':
         (("TightIso4"), ("NUM_TightRelIso_DEN_MediumID_PAR_eta", MEDIUM_ETA_BINS)),
         (("TightIso4"), ("NUM_TightRelIso_DEN_MediumID_PAR_pt_alleta_bin1", MEDIUM_PT_ALLETA_BINS)),
         (("TightIso4"), ("NUM_TightRelIso_DEN_MediumID_PAR_pt_spliteta_bin1", MEDIUM_PT_ETA_BINS)),
-        #(("TightIso4"), ("NUM_TightRelIso_DEN_MediumID_PAR_vtx", MEDIUM_VTX_BINS_ETA24)),
+        (("TightIso4"), ("NUM_TightRelIso_DEN_MediumID_PAR_vtx", MEDIUM_VTX_BINS_ETA24)),
         #(("TightIso4"), ("NUM_TightRelIso_DEN_MediumID_PAR_phi", MEDIUM_PHI_BINS)),
         ]
 
@@ -1321,11 +1325,11 @@ elif _id == 'highpt' and _iso == 'tktight':
         (("TightTkIso3"), ("NUM_TightRelTkIso_DEN_HighPtID_PAR_pt_alleta_bin1", HIGHPT_PT_ALLETA_BINS)),
         (("TightTkIso3"), ("NUM_TightRelTkIso_DEN_HighPtID_PAR_pt_spliteta_bin1", HIGHPT_PT_ETA_BINS)),
         (("TightTkIso3"), ("NUM_TightRelTkIso_DEN_HighPtID_PAR_vtx", HIGHPT_VTX_BINS_ETA24)),
-        (("TightTkIso3"), ("NUM_TightRelTkIso_DEN_HighPtID_PAR_phi", HIGHPT_PHI_BINS)),
+        #(("TightTkIso3"), ("NUM_TightRelTkIso_DEN_HighPtID_PAR_phi", HIGHPT_PHI_BINS)),
         ]
 
 #Loose tk Iso
-elif _id == 'highpt' and _iso == 'tktight':
+elif _id == 'highpt' and _iso == 'tkloose':
     if binning == 'eta':
         ID_BINS = [
         (("LooseTkIso3"), ("NUM_LooseRelTkIso_DEN_HighPtID_PAR_eta", HIGHPT_ETA_BINS)),
@@ -1354,7 +1358,7 @@ elif _id == 'highpt' and _iso == 'tktight':
         (("LooseTkIso3"), ("NUM_LooseRelTkIso_DEN_HighPtID_PAR_pt_alleta_bin1", HIGHPT_PT_ALLETA_BINS)),
         (("LooseTkIso3"), ("NUM_LooseRelTkIso_DEN_HighPtID_PAR_pt_spliteta_bin1", HIGHPT_PT_ETA_BINS)),
         (("LooseTkIso3"), ("NUM_LooseRelTkIso_DEN_HighPtID_PAR_vtx", HIGHPT_VTX_BINS_ETA24)),
-        (("LooseTkIso3"), ("NUM_LooseRelTkIso_DEN_HighPtID_PAR_phi", HIGHPT_PHI_BINS)),
+        #(("LooseTkIso3"), ("NUM_LooseRelTkIso_DEN_HighPtID_PAR_phi", HIGHPT_PHI_BINS)),
         ]
 
 #Loose tk Iso
@@ -1385,7 +1389,7 @@ elif _id == 'tight' and _iso == 'tkloose':
         (("LooseTkIso3"), ("NUM_LooseRelTkIso_DEN_TightID_PAR_pt_alleta_bin1", TIGHT_PT_ALLETA_BINS)),
         (("LooseTkIso3"), ("NUM_LooseRelTkIso_DEN_TightID_PAR_pt_spliteta_bin1", TIGHT_PT_ETA_BINS)),
         (("LooseTkIso3"), ("NUM_LooseRelTkIso_DEN_TightID_PAR_vtx", TIGHT_VTX_BINS_ETA24)),
-        (("LooseTkIso3"), ("NUM_LooseRelTkIso_DEN_TightID_PAR_phi", TIGHT_PHI_BINS)),
+        #(("LooseTkIso3"), ("NUM_LooseRelTkIso_DEN_TightID_PAR_phi", TIGHT_PHI_BINS)),
         ]
 
 else:
@@ -1417,26 +1421,29 @@ for ID, ALLBINS in ID_BINS:
     #shape = "vpvPlusCheb"
     if not "Iso" in ID:  #customize only for ID
         if _id == "highpt" :
-            elif (len(B.pair_newTuneP_probe_pt)==11): 
+            if (len(B.pair_newTuneP_probe_pt)==11): 
                 shape = cms.vstring("vpvPlusExpo","*pt_bin6*","vpvPlusCheb","*pt_bin7*","vpvPlusCheb","*pt_bin8*","vpvPlusCheb","*pt_bin9*","vpvPlusCheb")
         else:
-            elif (len(B.pt)==10): 
+            if (len(B.pt)==10): 
                 shape = cms.vstring("vpvPlusExpo","*pt_bin5*","vpvPlusCheb","*pt_bin6*","vpvPlusCheb","*pt_bin7*","vpvPlusCheb","*pt_bin8*","vpvPlusCheb")
     DEN = B.clone(); num = ID;    
 
+    mass_variable ="mass"
+    if _id == "highpt" :
+        mass_variable = "pair_newTuneP_mass"
     #compute isolation efficiency 
     if scenario == 'data_all':
         if num.find("Iso4") != -1: 
             setattr(module.Efficiencies, ID+"_"+X, cms.PSet(
                 EfficiencyCategoryAndState = cms.vstring(num,"below"),
-                UnbinnedVariables = cms.vstring("mass"),
+                UnbinnedVariables = cms.vstring(mass_variable),
                 BinnedVariables = DEN,
                 BinToPDFmap = shape
                 ))
         else:
             setattr(module.Efficiencies, ID+"_"+X, cms.PSet(
                 EfficiencyCategoryAndState = cms.vstring(num,"above"),
-                UnbinnedVariables = cms.vstring("mass"),
+                UnbinnedVariables = cms.vstring(mass_variable),
                 BinnedVariables = DEN,
                 BinToPDFmap = shape
                 ))
@@ -1446,14 +1453,14 @@ for ID, ALLBINS in ID_BINS:
         if num.find("Iso4") != -1: 
             setattr(module.Efficiencies, ID+"_"+X, cms.PSet(
                 EfficiencyCategoryAndState = cms.vstring(num,"below"),
-                UnbinnedVariables = cms.vstring("mass","weight"),
+                UnbinnedVariables = cms.vstring(mass_variable,"weight"),
                 BinnedVariables = DEN,
                 BinToPDFmap = shape
                 ))
         else:
             setattr(module.Efficiencies, ID+"_"+X, cms.PSet(
                 EfficiencyCategoryAndState = cms.vstring(num,"above"),
-                UnbinnedVariables = cms.vstring("mass","weight"),
+                UnbinnedVariables = cms.vstring(mass_variable,"weight"),
                 BinnedVariables = DEN,
                 BinToPDFmap = shape
                 ))

--- a/fitConfig/fitMuon.py
+++ b/fitConfig/fitMuon.py
@@ -1129,7 +1129,7 @@ elif _id == 'highpt' and _iso == 'noiso':
     if binning == 'eta':
         ID_BINS = [
         (("HighPt_zIPCut"), ("NUM_HighPtIDandIPCut_DEN_genTracks_PAR_eta", ETA_BINS)),
-        (("HighPt_zIPCut"), ("NUM_HighPtIDandIPCut_DEN_genTracks_PAR_eta", ETA_BINS_HPT)),
+        (("HighPt_zIPCut"), ("NUM_HighPtIDandIPCut_DEN_genTracks_PAR_eta_hpt", ETA_BINS_HPT)),
         ]
     elif binning == 'pt_alleta':
         ID_BINS = [
@@ -1142,7 +1142,7 @@ elif _id == 'highpt' and _iso == 'noiso':
     elif binning == 'all':
         ID_BINS = [
         (("HighPt_zIPCut"), ("NUM_HighPtIDandIPCut_DEN_genTracks_PAR_eta", ETA_BINS)),
-        (("HighPt_zIPCut"), ("NUM_HighPtIDandIPCut_DEN_genTracks_PAR_eta", ETA_BINS_HPT)),
+        (("HighPt_zIPCut"), ("NUM_HighPtIDandIPCut_DEN_genTracks_PAR_eta_hpt", ETA_BINS_HPT)),
         (("HighPt_zIPCut"), ("NUM_HighPtIDandIPCut_DEN_genTracks_PAR_pt_alleta_bin1", PT_ALLETA_BINS)),
         (("HighPt_zIPCut"), ("NUM_HighPtIDandIPCut_DEN_genTracks_PAR_pt_spliteta_bin1", PT_ETA_BINS)),
         (("HighPt_zIPCut"), ("NUM_HighPtIDandIPCut_DEN_genTracks_PAR_vtx", VTX_BINS_ETA24)),
@@ -1300,7 +1300,7 @@ elif _id == 'highpt' and _iso == 'tktight':
     if binning == 'eta':
         ID_BINS = [
         (("TightTkIso3"), ("NUM_TightRelTkIso_DEN_HighPtID_PAR_eta", HIGHPT_ETA_BINS)),
-        (("TightTkIso3"), ("NUM_TightRelTkIso_DEN_HighPtID_PAR_eta", HIGHPT_ETA_BINS_HPT)),
+        (("TightTkIso3"), ("NUM_TightRelTkIso_DEN_HighPtID_PAR_eta_hpt", HIGHPT_ETA_BINS_HPT)),
         ]
     elif binning == 'pt_alleta':
         ID_BINS = [
@@ -1321,7 +1321,7 @@ elif _id == 'highpt' and _iso == 'tktight':
     elif binning == 'all':
         ID_BINS = [
         (("TightTkIso3"), ("NUM_TightRelTkIso_DEN_HighPtID_PAR_eta", HIGHPT_ETA_BINS)),
-        (("TightTkIso3"), ("NUM_TightRelTkIso_DEN_HighPtID_PAR_eta", HIGHPT_ETA_BINS_HPT)),
+        (("TightTkIso3"), ("NUM_TightRelTkIso_DEN_HighPtID_PAR_eta_hpt", HIGHPT_ETA_BINS_HPT)),
         (("TightTkIso3"), ("NUM_TightRelTkIso_DEN_HighPtID_PAR_pt_alleta_bin1", HIGHPT_PT_ALLETA_BINS)),
         (("TightTkIso3"), ("NUM_TightRelTkIso_DEN_HighPtID_PAR_pt_spliteta_bin1", HIGHPT_PT_ETA_BINS)),
         (("TightTkIso3"), ("NUM_TightRelTkIso_DEN_HighPtID_PAR_vtx", HIGHPT_VTX_BINS_ETA24)),
@@ -1333,7 +1333,7 @@ elif _id == 'highpt' and _iso == 'tkloose':
     if binning == 'eta':
         ID_BINS = [
         (("LooseTkIso3"), ("NUM_LooseRelTkIso_DEN_HighPtID_PAR_eta", HIGHPT_ETA_BINS)),
-        (("LooseTkIso3"), ("NUM_LooseRelTkIso_DEN_HighPtID_PAR_eta", HIGHPT_ETA_BINS_HPT)),
+        (("LooseTkIso3"), ("NUM_LooseRelTkIso_DEN_HighPtID_PAR_eta_hpt", HIGHPT_ETA_BINS_HPT)),
         ]
     elif binning == 'pt_alleta':
         ID_BINS = [
@@ -1354,7 +1354,7 @@ elif _id == 'highpt' and _iso == 'tkloose':
     elif binning == 'all':
         ID_BINS = [
         (("LooseTkIso3"), ("NUM_LooseRelTkIso_DEN_HighPtID_PAR_eta", HIGHPT_ETA_BINS)),
-        (("LooseTkIso3"), ("NUM_LooseRelTkIso_DEN_HighPtID_PAR_eta", HIGHPT_ETA_BINS_HPT)),
+        (("LooseTkIso3"), ("NUM_LooseRelTkIso_DEN_HighPtID_PAR_eta_hpt", HIGHPT_ETA_BINS_HPT)),
         (("LooseTkIso3"), ("NUM_LooseRelTkIso_DEN_HighPtID_PAR_pt_alleta_bin1", HIGHPT_PT_ALLETA_BINS)),
         (("LooseTkIso3"), ("NUM_LooseRelTkIso_DEN_HighPtID_PAR_pt_spliteta_bin1", HIGHPT_PT_ETA_BINS)),
         (("LooseTkIso3"), ("NUM_LooseRelTkIso_DEN_HighPtID_PAR_vtx", HIGHPT_VTX_BINS_ETA24)),
@@ -1433,7 +1433,7 @@ for ID, ALLBINS in ID_BINS:
         mass_variable = "pair_newTuneP_mass"
     #compute isolation efficiency 
     if scenario == 'data_all':
-        if num.find("Iso4") != -1: 
+        if num.find("Iso4") != -1 or num.find("Iso3") != -1: 
             setattr(module.Efficiencies, ID+"_"+X, cms.PSet(
                 EfficiencyCategoryAndState = cms.vstring(num,"below"),
                 UnbinnedVariables = cms.vstring(mass_variable),

--- a/fitConfig/fitMuon.py
+++ b/fitConfig/fitMuon.py
@@ -1,4 +1,4 @@
-Iimport FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.Config as cms
 import sys, os, shutil
 from optparse import OptionParser
 ### USAGE: cmsRun fitMuonID.py TEST tight loose mc mc_all
@@ -95,7 +95,7 @@ if _id == "loose":
         Categories = cms.PSet(
             PF    = cms.vstring("PF Muon", "dummy[pass=1,fail=0]"),
             #tag selection
-            #tag_IsoMu20 = cms.vstring("PF Muon", "dummy[pass=1,fail=0]"),
+            tag_IsoMu22 = cms.vstring("PF Muon", "dummy[pass=1,fail=0]"),
         ),
     
         Expressions = cms.PSet(
@@ -183,7 +183,7 @@ elif _id == "medium":
         Categories = cms.PSet(
             Medium   = cms.vstring("Medium Id. Muon", "dummy[pass=1,fail=0]"),
             #tag selection
-            #tag_IsoMu20 = cms.vstring("PF Muon", "dummy[pass=1,fail=0]"),
+            tag_IsoMu22 = cms.vstring("PF Muon", "dummy[pass=1,fail=0]"),
         ),
     
         Expressions = cms.PSet(
@@ -274,7 +274,7 @@ elif _id == 'tight':
         Categories = cms.PSet(
             Tight2012 = cms.vstring("Tight Id. Muon", "dummy[pass=1,fail=0]"),
             #tag selection
-            #tag_IsoMu20 = cms.vstring("PF Muon", "dummy[pass=1,fail=0]"),
+            tag_IsoMu22 = cms.vstring("PF Muon", "dummy[pass=1,fail=0]"),
         ),
     
         Expressions = cms.PSet(
@@ -366,7 +366,7 @@ elif _id == 'highpt':
         Categories = cms.PSet(
             HighPt = cms.vstring("High-pT Id. Muon", "dummy[pass=1,fail=0]"),
             #tag selection
-            #tag_IsoMu20 = cms.vstring("PF Muon", "dummy[pass=1,fail=0]"),
+            tag_IsoMu22 = cms.vstring("PF Muon", "dummy[pass=1,fail=0]"),
         ),
     
         Expressions = cms.PSet(
@@ -458,7 +458,7 @@ elif _id == 'soft':
             TMOST = cms.vstring("TMOneStationTight", "dummy[pass=1,fail=0]"),
             Track_HP = cms.vstring("High-Purity muons", "dummy[pass=1,fail=0]"),
             #tag selection
-            #tag_IsoMu20 = cms.vstring("PF Muon", "dummy[pass=1,fail=0]"),
+            tag_IsoMu22 = cms.vstring("PF Muon", "dummy[pass=1,fail=0]"),
         ),
     
         Expressions = cms.PSet(
@@ -528,8 +528,8 @@ if _id == "highpt" :
         eta = cms.vdouble(-2.4, -2.1, -1.6, -1.2, -0.9, -0.3, -0.2, 0.2, 0.3, 0.9, 1.2, 1.6, 2.1, 2.4),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
-        tag_pt = cms.vdouble(21, 500),
-        #tag_IsoMu20 = cms.vstring("pass"), 
+        tag_pt = cms.vdouble(23, 500),
+        tag_IsoMu22 = cms.vstring("pass"), 
         tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
     )
     ETA_BINS_HPT = cms.PSet(
@@ -537,8 +537,8 @@ if _id == "highpt" :
         eta = cms.vdouble(-2.4, -2.1, -1.6, -1.2, -0.9, -0.3, -0.2, 0.2, 0.3, 0.9, 1.2, 1.6, 2.1, 2.4),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
-        tag_pt = cms.vdouble(21, 500),
-        #tag_IsoMu20 = cms.vstring("pass"), 
+        tag_pt = cms.vdouble(23, 500),
+        tag_IsoMu22 = cms.vstring("pass"), 
         tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
     )
     COARSE_ETA_BINS = cms.PSet(
@@ -547,41 +547,41 @@ if _id == "highpt" :
         abseta = cms.vdouble(0.0, 0.9, 1.2, 2.1, 2.4),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
-        tag_pt = cms.vdouble(21, 500),
-        #tag_IsoMu20 = cms.vstring("pass"), 
+        tag_pt = cms.vdouble(23, 500),
+        tag_IsoMu22 = cms.vstring("pass"), 
         tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
     )
     PT_ALLETA_BINS = cms.PSet(
         #Main
-        pair_newTuneP_probe_pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
+        pair_newTuneP_probe_pt     = cms.vdouble(20, 25, 30, 40, 50, 55, 60, 80, 120, 250, 500),
         abseta = cms.vdouble(  0.0, 2.4),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
-        tag_pt = cms.vdouble(21, 500),
-        #tag_IsoMu20 = cms.vstring("pass"), 
+        tag_pt = cms.vdouble(23, 500),
+        tag_IsoMu22 = cms.vstring("pass"), 
         tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
     )
     PT_ETA_BINS = cms.PSet(
         #Main
         #pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
-        pair_newTuneP_probe_pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120),
+        pair_newTuneP_probe_pt     = cms.vdouble(20, 25, 30, 40, 50, 55, 60, 120, 250, 500),
         #For testing bkg function
         #pt     = cms.vdouble(60, 80, 120, 200),
         abseta = cms.vdouble( 0., 0.9, 1.2, 2.1, 2.4),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
-        tag_pt = cms.vdouble(21, 500),
-        #tag_IsoMu20 = cms.vstring("pass"), 
+        tag_pt = cms.vdouble(23, 500),
+        tag_IsoMu22 = cms.vstring("pass"), 
         tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
         
     )
     PT_HIGHABSETA = cms.PSet(
-        pair_newTuneP_probe_pt     = cms.vdouble(20, 30, 40, 50, 60, 80, 120, 200),
+        pair_newTuneP_probe_pt     = cms.vdouble(20, 30, 40, 50, 55, 60, 80, 120,  250, 500),
         abseta = cms.vdouble(2.1, 2.4),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
-        tag_pt = cms.vdouble(21, 500),
-        #tag_IsoMu20 = cms.vstring("pass"), 
+        tag_pt = cms.vdouble(23, 500),
+        tag_IsoMu22 = cms.vstring("pass"), 
         tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
     )
     VTX_BINS_ETA24  = cms.PSet(
@@ -590,8 +590,8 @@ if _id == "highpt" :
         tag_nVertices = cms.vdouble(0.5,2.5,4.5,6.5,8.5,10.5,12.5,14.5,16.5,18.5,20.5,22.5,24.5,26.5,28.5,30.5),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
-        tag_pt = cms.vdouble(21, 500),
-        #tag_IsoMu20 = cms.vstring("pass"),
+        tag_pt = cms.vdouble(23, 500),
+        tag_IsoMu22 = cms.vstring("pass"),
         tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
     )
     PHI_BINS = cms.PSet(
@@ -600,8 +600,8 @@ if _id == "highpt" :
         phi =  cms.vdouble(-3.1416, -2.618, -2.0944, -1.5708, -1.0472, -0.5236, 0, 0.5236, 1.0472, 1.5708, 2.0944, 2.618, 3.1416),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
-        tag_pt = cms.vdouble(21, 500),
-        #tag_IsoMu20 = cms.vstring("pass"),
+        tag_pt = cms.vdouble(23, 500),
+        tag_IsoMu22 = cms.vstring("pass"),
         tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
     )
 else:
@@ -610,8 +610,8 @@ else:
         eta = cms.vdouble(-2.4, -2.1, -1.6, -1.2, -0.9, -0.3, -0.2, 0.2, 0.3, 0.9, 1.2, 1.6, 2.1, 2.4),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
-        tag_pt = cms.vdouble(21, 500),
-        #tag_IsoMu20 = cms.vstring("pass"), 
+        tag_pt = cms.vdouble(23, 500),
+        tag_IsoMu22 = cms.vstring("pass"), 
         tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
     )
     ETA_BINS_HPT = cms.PSet(
@@ -619,8 +619,8 @@ else:
         eta = cms.vdouble(-2.4, -2.1, -1.6, -1.2, -0.9, -0.3, -0.2, 0.2, 0.3, 0.9, 1.2, 1.6, 2.1, 2.4),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
-        tag_pt = cms.vdouble(21, 500),
-        #tag_IsoMu20 = cms.vstring("pass"), 
+        tag_pt = cms.vdouble(23, 500),
+        tag_IsoMu22 = cms.vstring("pass"), 
         tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
     )
     COARSE_ETA_BINS = cms.PSet(
@@ -629,41 +629,41 @@ else:
         abseta = cms.vdouble(0.0, 0.9, 1.2, 2.1, 2.4),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
-        tag_pt = cms.vdouble(21, 500),
-        #tag_IsoMu20 = cms.vstring("pass"), 
+        tag_pt = cms.vdouble(23, 500),
+        tag_IsoMu22 = cms.vstring("pass"), 
         tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
     )
     PT_ALLETA_BINS = cms.PSet(
         #Main
-        pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
+        pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 250, 500),
         abseta = cms.vdouble(  0.0, 2.4),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
-        tag_pt = cms.vdouble(21, 500),
-        #tag_IsoMu20 = cms.vstring("pass"), 
+        tag_pt = cms.vdouble(23, 500),
+        tag_IsoMu22 = cms.vstring("pass"), 
         tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
     )
     PT_ETA_BINS = cms.PSet(
         #Main
         #pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
-        pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120),
+        pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120, 250, 500),
         #For testing bkg function
         #pt     = cms.vdouble(60, 80, 120, 200),
         abseta = cms.vdouble( 0., 0.9, 1.2, 2.1, 2.4),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
-        tag_pt = cms.vdouble(21, 500),
-        #tag_IsoMu20 = cms.vstring("pass"), 
+        tag_pt = cms.vdouble(23, 500),
+        tag_IsoMu22 = cms.vstring("pass"), 
         tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
         
     )
     PT_HIGHABSETA = cms.PSet(
-        pt     = cms.vdouble(20, 30, 40, 50, 60, 80, 120, 200),
+        pt     = cms.vdouble(20, 30, 40, 50, 60, 80, 120, 250, 500),
         abseta = cms.vdouble(2.1, 2.4),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
-        tag_pt = cms.vdouble(21, 500),
-        #tag_IsoMu20 = cms.vstring("pass"), 
+        tag_pt = cms.vdouble(23, 500),
+        tag_IsoMu22 = cms.vstring("pass"), 
         tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
     )
     VTX_BINS_ETA24  = cms.PSet(
@@ -672,8 +672,8 @@ else:
         tag_nVertices = cms.vdouble(0.5,2.5,4.5,6.5,8.5,10.5,12.5,14.5,16.5,18.5,20.5,22.5,24.5,26.5,28.5,30.5),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
-        tag_pt = cms.vdouble(21, 500),
-        #tag_IsoMu20 = cms.vstring("pass"),
+        tag_pt = cms.vdouble(23, 500),
+        tag_IsoMu22 = cms.vstring("pass"),
         tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
     )
     PHI_BINS = cms.PSet(
@@ -682,8 +682,8 @@ else:
         phi =  cms.vdouble(-3.1416, -2.618, -2.0944, -1.5708, -1.0472, -0.5236, 0, 0.5236, 1.0472, 1.5708, 2.0944, 2.618, 3.1416),
         pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
         #tag selections
-        tag_pt = cms.vdouble(21, 500),
-        #tag_IsoMu20 = cms.vstring("pass"),
+        tag_pt = cms.vdouble(23, 500),
+        tag_IsoMu22 = cms.vstring("pass"),
         tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
     )
     
@@ -694,8 +694,8 @@ LOOSE_ETA_BINS = cms.PSet(
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     PF = cms.vstring("pass"), 
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"), 
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"), 
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 LOOSE_COARSE_ETA_BINS = cms.PSet(
@@ -705,29 +705,29 @@ LOOSE_COARSE_ETA_BINS = cms.PSet(
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     PF = cms.vstring("pass"), 
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"), 
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"), 
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 LOOSE_PT_ALLETA_BINS = cms.PSet(
-    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
+    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 250, 500),
     abseta = cms.vdouble(  0.0, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     PF = cms.vstring("pass"), 
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"), 
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"), 
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 LOOSE_PT_ETA_BINS = cms.PSet(
     #pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
-    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120),
+    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120,  250, 500),
     abseta = cms.vdouble( 0., 0.9, 1.2, 2.1, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     PF = cms.vstring("pass"), 
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"), 
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"), 
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 LOOSE_VTX_BINS_ETA24  = cms.PSet(
@@ -737,8 +737,8 @@ LOOSE_VTX_BINS_ETA24  = cms.PSet(
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     PF = cms.vstring("pass"), 
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"),
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"),
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 LOOSE_PHI_BINS = cms.PSet(
@@ -748,8 +748,8 @@ LOOSE_PHI_BINS = cms.PSet(
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     PF = cms.vstring("pass"), 
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"),
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"),
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
     )
 #MEDIUM
@@ -759,8 +759,8 @@ MEDIUM_ETA_BINS = cms.PSet(
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     Medium = cms.vstring("pass"), 
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"), 
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"), 
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 MEDIUM_COARSE_ETA_BINS = cms.PSet(
@@ -770,29 +770,29 @@ MEDIUM_COARSE_ETA_BINS = cms.PSet(
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     Medium = cms.vstring("pass"), 
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"), 
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"), 
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 MEDIUM_PT_ALLETA_BINS = cms.PSet(
-    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
+    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 250, 500),
     abseta = cms.vdouble(  0.0, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     Medium = cms.vstring("pass"), 
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"), 
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"), 
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 MEDIUM_PT_ETA_BINS = cms.PSet(
     #pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
-    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120),
+    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120, 250, 500),
     abseta = cms.vdouble( 0., 0.9, 1.2, 2.1, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     Medium = cms.vstring("pass"), 
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"), 
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"), 
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
     
 )
@@ -803,8 +803,8 @@ MEDIUM_VTX_BINS_ETA24  = cms.PSet(
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     Medium = cms.vstring("pass"), 
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"),
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"),
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 MEDIUM_PHI_BINS = cms.PSet(
@@ -814,8 +814,8 @@ MEDIUM_PHI_BINS = cms.PSet(
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     Medium = cms.vstring("pass"), 
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"),
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"),
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
     )
 #TIGHT
@@ -826,8 +826,8 @@ TIGHT_ETA_BINS = cms.PSet(
     Tight2012 = cms.vstring("pass"), 
     dzPV = cms.vdouble(-0.5, 0.5),
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"), 
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"), 
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 TIGHT_COARSE_ETA_BINS = cms.PSet(
@@ -838,31 +838,31 @@ TIGHT_COARSE_ETA_BINS = cms.PSet(
     Tight2012 = cms.vstring("pass"), 
     dzPV = cms.vdouble(-0.5, 0.5),
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"), 
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"), 
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 TIGHT_PT_ALLETA_BINS = cms.PSet(
-    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
+    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120,  250, 500),
     abseta = cms.vdouble(  0.0, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     Tight2012 = cms.vstring("pass"), 
     dzPV = cms.vdouble(-0.5, 0.5),
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"), 
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"), 
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 TIGHT_PT_ETA_BINS = cms.PSet(
     #pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
-    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120),
+    pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120, 250, 500),
     abseta = cms.vdouble( 0., 0.9, 1.2, 2.1, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     Tight2012 = cms.vstring("pass"), 
     dzPV = cms.vdouble(-0.5, 0.5),
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"), 
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"), 
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 TIGHT_VTX_BINS_ETA24  = cms.PSet(
@@ -873,8 +873,8 @@ TIGHT_VTX_BINS_ETA24  = cms.PSet(
     Tight2012 = cms.vstring("pass"), 
     dzPV = cms.vdouble(-0.5, 0.5),
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"),
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"),
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 TIGHT_PHI_BINS = cms.PSet(
@@ -885,8 +885,8 @@ TIGHT_PHI_BINS = cms.PSet(
     Tight2012 = cms.vstring("pass"), 
     dzPV = cms.vdouble(-0.5, 0.5),
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"),
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"),
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
     )
 
@@ -898,8 +898,8 @@ HIGHPT_ETA_BINS = cms.PSet(
     HighPt = cms.vstring("pass"), 
     dzPV = cms.vdouble(-0.5, 0.5),
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"), 
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"), 
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 HIGHPT_ETA_BINS_HPT = cms.PSet(
@@ -909,8 +909,8 @@ HIGHPT_ETA_BINS_HPT = cms.PSet(
     HighPt = cms.vstring("pass"), 
     dzPV = cms.vdouble(-0.5, 0.5),
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"), 
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"), 
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 HIGHPT_COARSE_ETA_BINS = cms.PSet(
@@ -921,31 +921,31 @@ HIGHPT_COARSE_ETA_BINS = cms.PSet(
     HighPt = cms.vstring("pass"), 
     dzPV = cms.vdouble(-0.5, 0.5),
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"), 
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"), 
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 HIGHPT_PT_ALLETA_BINS = cms.PSet(
-    pair_newTuneP_probe_pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
+    pair_newTuneP_probe_pt     = cms.vdouble(20, 25, 30, 40, 50, 55, 60, 80, 120,  250, 500),
     abseta = cms.vdouble(  0.0, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     HighPt = cms.vstring("pass"), 
     dzPV = cms.vdouble(-0.5, 0.5),
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"), 
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"), 
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 HIGHPT_PT_ETA_BINS = cms.PSet(
     #pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 80, 120, 200),
-    pair_newTuneP_probe_pt     = cms.vdouble(20, 25, 30, 40, 50, 60, 120),
+    pair_newTuneP_probe_pt     = cms.vdouble(20, 25, 30, 40, 50, 55, 60, 120,  250, 500),
     abseta = cms.vdouble( 0., 0.9, 1.2, 2.1, 2.4),
     pair_probeMultiplicity = cms.vdouble(0.5, 1.5),
     HighPt = cms.vstring("pass"), 
     dzPV = cms.vdouble(-0.5, 0.5),
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"), 
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"), 
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 HIGHPT_VTX_BINS_ETA24  = cms.PSet(
@@ -956,8 +956,8 @@ HIGHPT_VTX_BINS_ETA24  = cms.PSet(
     HighPt = cms.vstring("pass"), 
     dzPV = cms.vdouble(-0.5, 0.5),
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"),
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"),
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
 )
 HIGHPT_PHI_BINS = cms.PSet(
@@ -968,8 +968,8 @@ HIGHPT_PHI_BINS = cms.PSet(
     HighPt = cms.vstring("pass"), 
     dzPV = cms.vdouble(-0.5, 0.5),
     #tag selections
-    tag_pt = cms.vdouble(21, 500),
-    #tag_IsoMu20 = cms.vstring("pass"),
+    tag_pt = cms.vdouble(23, 500),
+    tag_IsoMu22 = cms.vstring("pass"),
     tag_combRelIsoPF04dBeta = cms.vdouble(-0.5, 0.2),
     )
 

--- a/fitConfig/fitMuon.py
+++ b/fitConfig/fitMuon.py
@@ -53,8 +53,8 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 if not _iso in ['noiso', 'loose', 'tight', 'tkloose', 'tktight']: 
     print '@ERROR: _iso should be \'noiso\', \'loose\', \'tight\', \'tkloose\' or \'tktight\'. You used', _iso, '.Abort'
     sys.exit()
-if not _id in ['loose', 'medium', 'medium_ichep', 'tight', 'soft', 'highpt']: 
-    print '@ERROR: _id should be \'loos\', \'medium\', \'medium_ichep\', \'tight\', \'soft\', or \'highpt\'. You used', _id, '.Abort'
+if not _id in ['loose', 'medium', 'tight', 'soft', 'highpt']: 
+    print '@ERROR: _id should be \'loos\', \'medium\', \'tight\', \'soft\', or \'highpt\'. You used', _id, '.Abort'
     sys.exit()
 
 #_*_*_*_*_*_*_*_*_*_*_*_*


### PR DESCRIPTION
1. match with IsoMu22 as tag
2. Added high-pT ID
3. added t iso (tight and high-pT ID)
4. Moved to "new soft and medium"
5. Extended all pT plots (120 - 200 - 500 <= checked that the switch between exp and cheb works)
6. Added for high pT a bin at 55 GeV (not the 53 used by Z' but I guess it is OK) and plots vs eta above 55 GeV

Now it would miss the CMS shape
